### PR TITLE
Fix: Fundamentally redesign Firebase sync to respect Firebase as source of truth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,4 @@ security-report.json
 
 # Documentation files
 PROJECT_DOCUMENTATION.md
+.env*.local

--- a/src/__tests__/firebaseSync.test.js
+++ b/src/__tests__/firebaseSync.test.js
@@ -67,42 +67,25 @@ describe("Firebase Sync Service", () => {
     });
   });
 
-  describe("markAsDeleted", () => {
-    it("should mark item as deleted", () => {
-      const itemId = "test-123";
-      const dataType = "transactions";
-
-      firebaseSync.markAsDeleted(itemId, dataType);
-
-      const deletedItems = firebaseSync.getDeletedItems();
-      expect(deletedItems).toContain(`${dataType}:${itemId}`);
-    });
-  });
-
-  describe("clearDeletedItems", () => {
-    it("should clear deleted items", () => {
-      // Add some deleted items first
-      firebaseSync.markAsDeleted("test-1", "transactions");
-      firebaseSync.markAsDeleted("test-2", "accounts");
-
-      expect(firebaseSync.getDeletedItems()).toHaveLength(2);
-
-      firebaseSync.clearDeletedItems();
-
-      expect(firebaseSync.getDeletedItems()).toHaveLength(0);
-    });
-  });
-
   describe("clearAllSyncState", () => {
     it("should clear all sync state", () => {
-      // Add some deleted items first
-      firebaseSync.markAsDeleted("test-1", "transactions");
+      // Test that the method exists and works
+      expect(() => firebaseSync.clearAllSyncState()).not.toThrow();
 
-      expect(firebaseSync.getDeletedItems()).toHaveLength(1);
+      const status = firebaseSync.getSyncStatus();
+      expect(status.lastSyncTime).toBeNull();
+    });
+  });
 
-      firebaseSync.clearAllSyncState();
+  describe("forceSync", () => {
+    it("should have forceSync method", () => {
+      expect(typeof firebaseSync.forceSync).toBe("function");
+    });
+  });
 
-      expect(firebaseSync.getDeletedItems()).toHaveLength(0);
+  describe("initialization", () => {
+    it("should have initialize method", () => {
+      expect(typeof firebaseSync.initialize).toBe("function");
     });
   });
 });

--- a/src/pages/AccountsPage.jsx
+++ b/src/pages/AccountsPage.jsx
@@ -158,7 +158,7 @@ const AccountsPage = () => {
     try {
       const options = deleteTransactions ? { deleteTransactions: true } : {};
       console.log("🗑️ Attempting to delete account with options:", options);
-      
+
       const result = await deleteAccount(accountToDelete.id, options);
 
       if (result.success) {
@@ -166,7 +166,7 @@ const AccountsPage = () => {
         showSuccess(result.message || "Account deleted successfully");
         setShowDeleteConfirm(false);
         setAccountToDelete(null);
-        
+
         // Force refresh accounts to ensure UI is in sync
         console.log("🔄 Force refreshing accounts after deletion...");
         try {

--- a/src/pages/AccountsPage.jsx
+++ b/src/pages/AccountsPage.jsx
@@ -24,6 +24,8 @@ const AccountsPage = () => {
     isLoading,
     initialize,
     isInitialized,
+    forceRefreshAccounts,
+    removeAccountFromState,
   } = useProductionStore();
   const { showSuccess, showError, showWarning } = useNotifications();
   const [showAddModal, setShowAddModal] = useState(false);
@@ -155,16 +157,33 @@ const AccountsPage = () => {
 
     try {
       const options = deleteTransactions ? { deleteTransactions: true } : {};
+      console.log("🗑️ Attempting to delete account with options:", options);
+      
       const result = await deleteAccount(accountToDelete.id, options);
 
       if (result.success) {
+        console.log("✅ Account deletion succeeded:", result);
         showSuccess(result.message || "Account deleted successfully");
         setShowDeleteConfirm(false);
         setAccountToDelete(null);
+        
+        // Force refresh accounts to ensure UI is in sync
+        console.log("🔄 Force refreshing accounts after deletion...");
+        try {
+          await forceRefreshAccounts();
+          console.log("✅ Accounts refreshed successfully");
+        } catch (refreshError) {
+          console.warn("⚠️ Failed to refresh accounts:", refreshError);
+          // Fallback: manually remove from state
+          console.log("🔄 Using fallback: manually removing from state");
+          removeAccountFromState(accountToDelete.id);
+        }
       } else {
+        console.error("❌ Account deletion failed:", result);
         showError(result.message || "Failed to delete account");
       }
     } catch (error) {
+      console.error("❌ Account deletion error:", error);
       if (error.message.includes("existing transactions")) {
         // Show a more helpful error with options
         showWarning(


### PR DESCRIPTION
## Problem

When manually deleting data from Firebase backend, the sync service was automatically restoring it on browser refresh. This happened because the sync logic was treating deleted data as 'missing' data that needed to be restored.

## Root Cause

The  method in  had complex logic that tried to track deleted items and prevent restoration, but this was fundamentally flawed because:
1. It tried to maintain local state about what was deleted
2. It didn't respect Firebase as the authoritative source of truth
3. The deletion tracking was complex and error-prone

## Solution

**Completely redesigned the sync logic to respect Firebase as the source of truth:**

1. **Simplified merge logic**: If data exists in Firebase but not locally → add it locally. If data exists locally but not in Firebase → remove it locally.

2. **Removed complex deletion tracking**: No more localStorage tracking, deleted items sets, or complex restoration prevention logic.

3. **Firebase-first approach**: When you manually delete from Firebase, the sync service will automatically remove it from local state on the next sync.

4. **Cleaner state management**: The production store now properly updates local state immediately after deletion and refreshes real-time listeners.

## Key Changes

- Simplified  method to respect Firebase as source of truth
- Added immediate local state updates and listener refresh after deletion
- Improved authentication handling and deletion verification
- Added fallback state management and better error handling

## Testing

1. Delete an account from the UI
2. Manually delete data from Firebase console
3. Refresh the browser
4. Verify that manually deleted data doesn't reappear

This fix ensures that Firebase is truly the source of truth and manual deletions are respected.