### PR TITLE
feat: Sidebar welcome uses profile name

### DIFF
--- a/src/contexts/FirebaseAuthContext.jsx
+++ b/src/contexts/FirebaseAuthContext.jsx
@@ -154,6 +154,7 @@ export const FirebaseAuthProvider = ({ children }) => {
         try {
           // Get or create user profile
           const userDoc = await getDoc(doc(db, "users", firebaseUser.uid));
+          let profileData = null;
 
           if (!userDoc.exists()) {
             console.log(
@@ -182,6 +183,7 @@ export const FirebaseAuthProvider = ({ children }) => {
           } else {
             // Only update if there are actual changes to avoid unnecessary writes
             const existingProfile = userDoc.data();
+            profileData = existingProfile;
             const hasChanges =
               existingProfile.email !== firebaseUser.email ||
               existingProfile.name !==
@@ -219,7 +221,11 @@ export const FirebaseAuthProvider = ({ children }) => {
           const user = {
             id: firebaseUser.uid,
             email: firebaseUser.email,
-            name: firebaseUser.displayName || firebaseUser.email,
+            // Prefer Firestore profile name when available; fallback to displayName/email
+            name:
+              (profileData && profileData.name) ||
+              firebaseUser.displayName ||
+              firebaseUser.email,
             photoURL: firebaseUser.photoURL,
           };
 


### PR DESCRIPTION
QoL: Sidebar greeting now prefers Firestore profile name; falls back to displayName/email.

- Updates  to hydrate  from Firestore profile when available
- No UI changes required; / already derive first-name from 
- Linted and pushed branch

QA:
- Login with profile having  set -> shows name
- Login with no profile  -> shows displayName or email prefix

No data migrations; read-only change to auth mapping.