### PR TITLE
Fix dashboard net worth and financial card formatting consistency

### DIFF
--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -354,9 +354,7 @@ const DashboardPage = ({
         <div className="flex items-center justify-between">
           <div>
             <p className="text-blue-100">Total Net Worth</p>
-            <p className="text-3xl font-bold">
-              ${totalBalance.toLocaleString()}
-            </p>
+            <p className="text-3xl font-bold">${totalBalance.toFixed(2)}</p>
           </div>
           <DollarSign className="w-12 h-12 text-blue-200" />
         </div>
@@ -366,14 +364,14 @@ const DashboardPage = ({
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
         <QuickAnalyticsCard
           title="Monthly Income"
-          value={`$${monthlyIncome.toLocaleString()}`}
+          value={`$${monthlyIncome.toFixed(2)}`}
           change={incomeChangeText}
           icon={TrendingUp}
           trend={incomeTrend}
         />
         <QuickAnalyticsCard
           title="Monthly Expenses"
-          value={`$${monthlyExpenses.toLocaleString()}`}
+          value={`$${monthlyExpenses.toFixed(2)}`}
           change={expenseChangeText}
           icon={TrendingDown}
           trend={expenseTrend}


### PR DESCRIPTION
## Summary
Fixes formatting inconsistencies between dashboard and analytics pages for net worth and financial metrics.

## Problem
- Dashboard net worth card showed values like 3246.1 instead of 3246.10
- Monthly income and expenses cards also had inconsistent decimal formatting
- Analytics page always showed 2 decimal places while dashboard used toLocaleString()

## Solution
- Changed dashboard net worth display from `toLocaleString()` to `toFixed(2)`
- Updated monthly income and expenses cards to use `toFixed(2)` for consistency
- Both dashboard and analytics now show identical formatting with 2 decimal places

## Changes
- `src/pages/DashboardPage.jsx`: Updated formatting for net worth, monthly income, and monthly expenses cards

## Testing
- Verified both pages now show consistent formatting
- All values display with exactly 2 decimal places
- No functional changes to calculations, only display formatting